### PR TITLE
No file extension was added to filenames with points

### DIFF
--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -87,7 +87,8 @@ module Sprockets
       return source if uri.absolute?
       
       # Append extension if necessary
-      if options[:ext] && File.extname(uri.path).empty?
+      source_ext = File.extname(source)
+      if options[:ext] && source_ext != ".#{options[:ext]}"
         uri.path << ".#{options[:ext]}"
       end
       

--- a/lib/sprockets/helpers/version.rb
+++ b/lib/sprockets/helpers/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Helpers
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end

--- a/spec/sprockets-helpers_spec.rb
+++ b/spec/sprockets-helpers_spec.rb
@@ -271,10 +271,12 @@ describe Sprockets::Helpers do
     context 'with regular files' do
       it 'appends the js extension' do
         context.javascript_path('/path/to/file').should == '/path/to/file.js'
+        context.javascript_path('/path/to/file.min').should == '/path/to/file.min.js'
       end
       
       it 'prepends the javascripts dir' do
         context.javascript_path('main').should == '/javascripts/main.js'
+        context.javascript_path('main.min').should == '/javascripts/main.min.js'
       end
     end
   end
@@ -283,10 +285,12 @@ describe Sprockets::Helpers do
     context 'with regular files' do
       it 'appends the css extension' do
         context.stylesheet_path('/path/to/file').should == '/path/to/file.css'
+        context.stylesheet_path('/path/to/file.min').should == '/path/to/file.min.css'
       end
       
       it 'prepends the stylesheets dir' do
         context.stylesheet_path('main').should == '/stylesheets/main.css'
+        context.stylesheet_path('main.min').should == '/stylesheets/main.min.css'
       end
     end
   end


### PR DESCRIPTION
Hi Pete,

similar to https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/rails/helpers/rails_helper.rb,
I add a check for the file extension for js and css, that it is '.js' or '.css'.

Before:
javascript_path 'jquery.min'
-> javascripts/jquery.min

Now:
javascript_path 'jquery.min'
-> javascripts/jquery.min.js

Best,
Daniel
