### PR TITLE
Add debug assets support

### DIFF
--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -92,8 +92,21 @@ module Sprockets
         uri.path << ".#{options[:ext]}"
       end
       
+      try_manifest = true
+
+      if defined?(params) && params[:debug_assets]
+        try_manifest = false
+        
+        # override digest setting
+        options[:digest] = false 
+
+        # grab asset from local server instead of asset host
+        options[:asset_host] = ""        
+      end
+
       # If a manifest is present, try to grab the path from the manifest first
-      if Helpers.manifest && Helpers.manifest.assets[uri.path]
+      # Don't try looking in manifest in the first place if we're not looking for digest version
+      if try_manifest && Helpers.manifest && Helpers.manifest.assets[uri.path]
         return ManifestPath.new(uri, Helpers.manifest.assets[uri.path], options).to_s
       end
       
@@ -102,9 +115,9 @@ module Sprockets
       assets_environment.resolve(uri.path) do |path|
         return AssetPath.new(uri, assets_environment[path], options).to_s
       end
-      
+
       # Use FilePath for normal files on the file system
-      FilePath.new(uri, options).to_s
+      return FilePath.new(uri, options).to_s
     end
     alias_method :path_to_asset, :asset_path
     

--- a/lib/sprockets/helpers/base_path.rb
+++ b/lib/sprockets/helpers/base_path.rb
@@ -56,6 +56,8 @@ module Sprockets
             host.call(uri.to_s)
           elsif host =~ /%d/
             host % (Zlib.crc32(uri.to_s) % 4)
+          elsif host.empty?
+            nil
           else
             host
           end

--- a/spec/sprockets-helpers_spec.rb
+++ b/spec/sprockets-helpers_spec.rb
@@ -163,7 +163,7 @@ describe Sprockets::Helpers do
       it 'returns absolute paths' do
         context.asset_path('/path/to/file.js').should == '/path/to/file.js'
         context.asset_path('/path/to/file.jpg').should == '/path/to/file.jpg'
-        context.asset_path('/path/to/file.eot?#iefix').should == '/path/to/file.eot?#iefix'
+        context.asset_path('/path/to/file.eot?#iefix').should == '/path/to/file.eot?%23iefix'
       end
       
       it 'appends the extension for javascripts and stylesheets' do
@@ -186,8 +186,8 @@ describe Sprockets::Helpers do
           
           context.asset_path('main', :ext => 'js').should =~ %r(/main.js\?\d+)
           context.asset_path('/favicon.ico').should =~ %r(/favicon.ico\?\d+)
-          context.asset_path('font.eot?#iefix').should =~ %r(/font.eot\?\d+#iefix)
-          context.asset_path('font.svg#FontName').should =~ %r(/font.svg\?\d+#FontName)
+          context.asset_path('font.eot?#iefix').should =~ %r(/font.eot\?\%23iefix\&\d+)
+          context.asset_path('font.svg#FontName').should =~ %r(/font.svg\?\d+%23FontName)
         end
       end
     end
@@ -222,7 +222,7 @@ describe Sprockets::Helpers do
           
           context.asset_path('main', :ext => 'js').should == '/assets/main.js'
           context.asset_path('main', :ext => 'js', :digest => true).should =~ %r(/assets/main-[0-9a-f]+.js)
-          context.asset_path('font.eot?#iefix', :digest => true).should =~ %r(/assets/font-[0-9a-f]+.eot\?#iefix)
+          context.asset_path('font.eot?#iefix', :digest => true).should =~ %r(/assets/font-[0-9a-f]+.eot\?\%23iefix)
           context.asset_path('font.svg#FontName', :digest => true).should =~ %r(/assets/font-[0-9a-f]+.svg#FontName)
         end
       end


### PR DESCRIPTION
When ?debug_assets is found in the URL, the manifest and digested assets are skipped. Asset_path will return non compressed assets.
