### PR TITLE
tag helpers with optional expanding

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,4 +23,26 @@ RSpec.configure do |config|
     pathname ||= Pathname.new(File.join('assets', logical_path)).expand_path
     env.context_class.new env, logical_path, pathname
   end
+
+  # Exemplary file system layout for usage in test-construct
+  def assets_layout(construct)
+    lambda { |c|
+      c.file('assets/main.js') do |f|
+        f << "//= require a\n"
+        f << "//= require b\n"
+      end
+      c.file('assets/a.js')
+      c.file('assets/b.js')
+
+      c.file('assets/main.css') do |f|
+        f << "/*\n"
+        f << "*= require a\n"
+        f << "*= require b\n"
+        f << "*/\n"
+      end
+      c.file('assets/a.css')
+      c.file('assets/b.css')
+    }.call(construct)
+  end
+
 end


### PR DESCRIPTION
'assets_tag' receives a block to construct an arbitrary tag. 'javascript_tag' and 'stylesheet_tag' have corresponding tags predefined.

With options[:expand], all assets required by the asset given as source generate a tag, with body=1 appended to the uri. This option can be toggled globally.
