### PR TITLE
Correctly handle global :expand => true in asset_tag

### DIFF
--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -136,7 +136,8 @@ module Sprockets
 
     def asset_tag(source, options = {}, &block)
       raise ::ArgumentError, 'block missing' unless block
-      path = asset_path source, { :expand => Helpers.expand }.merge(options)
+      options = { :expand => Helpers.expand }.merge(options)
+      path = asset_path source, options
       if options[:expand] && path.respond_to?(:map)
         return path.map(&block).join()
       else


### PR DESCRIPTION
We just had a problem where when setting :expand to true in the configuration block would yield from (for example) `<%== stylesheet_tag 'foo'%>`:

``` html
<link rel="stylesheet" href="["/assets/bar-14fb62decc150c8cce8a65e66490ffc4.css?body=1", "/assets/foo-39e72dfc94a56d798e7a13dfb2e9598c.css?body=1"]">
```

This change fixes things such that the expected

``` html
<link rel="stylesheet" href="/assets/coderay-14fb62decc150c8cce8a65e66490ffc4.css?body=1">
<link rel="stylesheet" href="/assets/apidocs-39e72dfc94a56d798e7a13dfb2e9598c.css?body=1">
```

gets emitted.
