### PR TITLE
Ensure that changes to the source file in asset_tag force the current asset (for example, an erb file) to have its cache invalided.

### DIFF
--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -146,7 +146,9 @@ module Sprockets
       options = { :expand => Helpers.debug || Helpers.expand, :debug => Helpers.debug }.merge(options)
 
       # Ensure that changes to source invalidate the current asset
-      depend_on_asset source
+      if respond_to? :depend_on_asset
+        depend_on_asset source
+      end
 
       path = asset_path source, options
       if options[:expand] && path.respond_to?(:map)

--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -144,6 +144,10 @@ module Sprockets
     def asset_tag(source, options = {}, &block)
       raise ::ArgumentError, 'block missing' unless block
       options = { :expand => Helpers.debug || Helpers.expand, :debug => Helpers.debug }.merge(options)
+
+      # Ensure that changes to source invalidate the current asset
+      depend_on_asset source
+
       path = asset_path source, options
       if options[:expand] && path.respond_to?(:map)
         return path.map(&block).join("\n")


### PR DESCRIPTION
This is particularly helpful when debug/expanded is turned on and you are using javascript_tag or stylesheet_tag. Without this, if you changed the require directives for a js/css file you were including, the erb wouldn't update until you modified/touched it as well.