### PR TITLE
support for media attribute on stylesheet_tag helper

### DIFF
--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -160,9 +160,11 @@ module Sprockets
     end
 
     def stylesheet_tag(source, options = {})
+      media = options.delete(:media)
+      media_attr = media.nil? ? nil : " media=\"#{media}\""
       options = Helpers.default_path_options[:stylesheet_path].merge(options)
       asset_tag(source, options) do |path|
-        %Q(<link rel="stylesheet" href="#{path}">)
+        %Q(<link rel="stylesheet" href="#{path}"#{media_attr}>)
       end
     end
 

--- a/spec/sprockets-helpers_spec.rb
+++ b/spec/sprockets-helpers_spec.rb
@@ -520,6 +520,10 @@ describe Sprockets::Helpers do
       expect(context.stylesheet_tag('main')).to eq('<link rel="stylesheet" href="/stylesheets/main.css">')
     end
 
+    it 'uses media attribute when provided' do
+      expect(context.stylesheet_tag('main', :media => "print")).to eq('<link rel="stylesheet" href="/stylesheets/main.css" media="print">')
+    end
+
     describe 'when expanding' do
       it 'generates stylesheet tag for each stylesheet asset' do
         within_construct do |construct|


### PR DESCRIPTION
Currently there's no way to specify the media attribute on the links. This patch provides this functionality, with passing test.
