### PR TITLE
Use respond_to? instead of checking type

### DIFF
--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -36,7 +36,7 @@ module Sprockets
       # This defaults to '/assets'.
       def prefix
         @prefix ||= '/assets'
-        @prefix.is_a?(Array) ? "/#{@prefix.first}" : @prefix
+        @prefix.respond_to?(:first) ? "/#{@prefix.first}" : @prefix
       end
       attr_writer :prefix
 


### PR DESCRIPTION
Because it's a generally a bad practice to check the class type
