### PR TITLE
Cleaning up class variables after specs

### DIFF
--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -144,7 +144,7 @@ module Sprockets
 
     def asset_tag(source, options = {}, &block)
       raise ::ArgumentError, 'block missing' unless block
-      options = { :expand => Helpers.debug || Helpers.expand, :debug => Helpers.debug }.merge(options)
+      options = { :expand => !!Helpers.debug || !!Helpers.expand, :debug => Helpers.debug }.merge(options)
 
       path = asset_path(source, options)
       output = if options[:expand] && path.respond_to?(:map)

--- a/spec/sprockets-helpers_spec.rb
+++ b/spec/sprockets-helpers_spec.rb
@@ -395,6 +395,11 @@ describe Sprockets::Helpers do
   end
 
   describe '#asset_tag' do
+    after do
+      Sprockets::Helpers.debug = nil
+      Sprockets::Helpers.expand = nil
+    end
+
     it 'receives block to generate tag' do
       actual = context.asset_tag('main.js') { |path| "<script src=#{path}></script>" }
       expect(actual).to eq('<script src=/main.js></script>')
@@ -540,6 +545,14 @@ describe Sprockets::Helpers do
   end
 
   describe 'Sinatra integration' do
+    after do
+      ::Sprockets::Helpers.environment = nil
+      ::Sprockets::Helpers.public_path = nil
+      ::Sprockets::Helpers.digest = nil
+      ::Sprockets::Helpers.prefix = nil
+      ::Sprockets::Helpers.expand = nil
+    end
+
     it 'adds the helpers' do
       app = Class.new(Sinatra::Base) do
         register Sinatra::Sprockets::Helpers


### PR DESCRIPTION
Some specs were setting class variables values and not cleaning them up making specs break depending on the order of execution.

I thought of creating a ```Sprockets::Helpers.reset_config``` method or something like that, but since it's something mostly for tests, I think it's better to keep it in the specs only.

Also, the first commit, is about a spec who was comparing two class variables which were initialized as nil, so depending on their values it could return either nil, true or false. I forced them to return only true or false.