### PR TITLE
Sprockets 3.x support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -37,3 +37,15 @@ end
 appraise 'sprockets-2.9' do
   gem 'sprockets', '~> 2.9.0'
 end
+
+appraise 'sprockets-3.0' do
+  gem 'sprockets', '~> 3.0.0'
+end
+
+appraise 'sprockets-3.1' do
+  gem 'sprockets', '~> 3.1.0'
+end
+
+appraise 'sprockets-3.2' do
+  gem 'sprockets', '~> 3.2.0'
+end

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,3 @@
-appraise 'sprockets-2.0' do
-  gem 'sprockets', '~> 2.0.0'
-end
-
-appraise 'sprockets-2.1' do
-  gem 'sprockets', '~> 2.1.0'
-end
-
 appraise 'sprockets-2.2' do
   gem 'sprockets', '~> 2.2.0'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sprockets-helpers
 
-**Asset path helpers for Sprockets 2.x applications**
+**Asset path helpers for Sprockets 3.x & <= 2.2 applications**
 
 Sprockets::Helpers adds the asset_path helpers, familiar to Rails developers, to Sprockets 2.x assets and applications.
 

--- a/gemfiles/sprockets_2.0.gemfile
+++ b/gemfiles/sprockets_2.0.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.0.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_2.1.gemfile
+++ b/gemfiles/sprockets_2.1.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.1.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_2.3.gemfile
+++ b/gemfiles/sprockets_2.3.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.3.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_2.4.gemfile
+++ b/gemfiles/sprockets_2.4.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.4.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_2.5.gemfile
+++ b/gemfiles/sprockets_2.5.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.5.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_2.6.gemfile
+++ b/gemfiles/sprockets_2.6.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.6.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_2.7.gemfile
+++ b/gemfiles/sprockets_2.7.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.7.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_2.8.gemfile
+++ b/gemfiles/sprockets_2.8.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.8.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_2.9.gemfile
+++ b/gemfiles/sprockets_2.9.gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 
 gem "sprockets", "~> 2.9.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/sprockets_3.0.gemfile
+++ b/gemfiles/sprockets_3.0.gemfile
@@ -2,6 +2,6 @@
 
 source "http://rubygems.org"
 
-gem "sprockets", "~> 2.2.0"
+gem "sprockets", "~> 3.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/sprockets_3.1.gemfile
+++ b/gemfiles/sprockets_3.1.gemfile
@@ -2,6 +2,6 @@
 
 source "http://rubygems.org"
 
-gem "sprockets", "~> 2.2.0"
+gem "sprockets", "~> 3.1.0"
 
 gemspec :path => "../"

--- a/gemfiles/sprockets_3.2.gemfile
+++ b/gemfiles/sprockets_3.2.gemfile
@@ -2,6 +2,6 @@
 
 source "http://rubygems.org"
 
-gem "sprockets", "~> 2.2.0"
+gem "sprockets", "~> 3.2.0"
 
 gemspec :path => "../"

--- a/lib/sprockets/helpers/version.rb
+++ b/lib/sprockets/helpers/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Helpers
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,19 +29,16 @@ RSpec.configure do |config|
   def context(logical_path = 'application.js', pathname = nil)
     pathname ||= Pathname.new(File.join('assets', logical_path)).expand_path
 
-      # env.context_class.class_eval do
-      #   def asset_path(path, options = {})
-      #     link_asset(path)
-      #     "/#{path}"
-      #   end
-      # end
-
+    if Sprockets::Helpers.are_using_sprockets_3
       env.context_class.new(
         :environment => env,
         :name => logical_path,
         :filename => pathname,
         :metadata => {}
       )
+    else
+      env.context_class.new env, logical_path, pathname
+    end
   end
 
   # Exemplary file system layout for usage in test-construct

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'sprockets'
 require 'sprockets-helpers'
 require 'sinatra/base'
 require 'sinatra/sprockets/helpers'
-require 'construct'
+require 'test_construct'
 require 'pathname'
 
 # Requires supporting files with custom matchers and macros, etc,
@@ -10,7 +10,7 @@ require 'pathname'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
-  config.include Construct::Helpers
+  config.include TestConstruct::Helpers
 
   # Disable old `should` syntax
   config.expect_with :rspec do |c|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,20 @@ RSpec.configure do |config|
   # Returns a fresh context, that can be used to test helpers.
   def context(logical_path = 'application.js', pathname = nil)
     pathname ||= Pathname.new(File.join('assets', logical_path)).expand_path
-    env.context_class.new env, logical_path, pathname
+
+      # env.context_class.class_eval do
+      #   def asset_path(path, options = {})
+      #     link_asset(path)
+      #     "/#{path}"
+      #   end
+      # end
+
+      env.context_class.new(
+        :environment => env,
+        :name => logical_path,
+        :filename => pathname,
+        :metadata => {}
+      )
   end
 
   # Exemplary file system layout for usage in test-construct

--- a/spec/sprockets-helpers_spec.rb
+++ b/spec/sprockets-helpers_spec.rb
@@ -448,7 +448,7 @@ describe Sprockets::Helpers do
           tags = context.asset_tag('main.js', :expand => true) do |path|
             "<script src=\"#{path}\"></script>"
           end
-          expect(tags.split('</script>')).to have(3).scripts
+          expect(tags.split('</script>').size).to eq(3)
           expect(tags).to include('<script src="/assets/main.js?body=1"></script>')
           expect(tags).to include('<script src="/assets/a.js?body=1"></script>')
           expect(tags).to include('<script src="/assets/b.js?body=1"></script>')
@@ -474,7 +474,7 @@ describe Sprockets::Helpers do
             tags = context.asset_tag('main.js') do |path|
               "<script src=\"#{path}\"></script>"
             end
-            expect(tags.split('</script>')).to have(3).scripts
+            expect(tags.split('</script>').size).to eq(3)
             expect(tags).to include('<script src="/assets/main.js?body=1"></script>')
             expect(tags).to include('<script src="/assets/a.js?body=1"></script>')
             expect(tags).to include('<script src="/assets/b.js?body=1"></script>')

--- a/spec/sprockets-helpers_spec.rb
+++ b/spec/sprockets-helpers_spec.rb
@@ -574,7 +574,7 @@ describe Sprockets::Helpers do
 
       expect(Sprockets::Helpers.environment).to be(custom_env)
       expect(Sprockets::Helpers.prefix).to eq('/static')
-      expect(Sprockets::Helpers.digest).to be_true
+      expect(Sprockets::Helpers.digest).to be_truthy
     end
 
     it 'uses first prefix if assets_prefix is an array' do
@@ -607,7 +607,7 @@ describe Sprockets::Helpers do
 
       expect(Sprockets::Helpers.environment).to be(custom_env)
       expect(Sprockets::Helpers.prefix).to eq('/static')
-      expect(Sprockets::Helpers.expand).to be_true
+      expect(Sprockets::Helpers.expand).to be_truthy
     end
   end
 end

--- a/spec/sprockets-helpers_spec.rb
+++ b/spec/sprockets-helpers_spec.rb
@@ -7,10 +7,12 @@ describe Sprockets::Helpers do
         c.file 'assets/main.css'
 
         expect(context.asset_path('main.css')).to eq('/assets/main.css')
+
         Sprockets::Helpers.configure do |config|
           config.digest = true
           config.prefix = '/themes'
         end
+
         expect(context.asset_path('main.css')).to match(%r(/themes/main-[0-9a-f]+.css))
         Sprockets::Helpers.digest = nil
         Sprockets::Helpers.prefix = nil
@@ -449,9 +451,9 @@ describe Sprockets::Helpers do
             "<script src=\"#{path}\"></script>"
           end
           expect(tags.split('</script>').size).to eq(3)
-          expect(tags).to include('<script src="/assets/main.js?body=1"></script>')
-          expect(tags).to include('<script src="/assets/a.js?body=1"></script>')
-          expect(tags).to include('<script src="/assets/b.js?body=1"></script>')
+          expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
+          expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
+          expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
         end
       end
     end
@@ -475,9 +477,9 @@ describe Sprockets::Helpers do
               "<script src=\"#{path}\"></script>"
             end
             expect(tags.split('</script>').size).to eq(3)
-            expect(tags).to include('<script src="/assets/main.js?body=1"></script>')
-            expect(tags).to include('<script src="/assets/a.js?body=1"></script>')
-            expect(tags).to include('<script src="/assets/b.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
 
             Sprockets::Helpers.debug = false
             Sprockets::Helpers.prefix = nil
@@ -506,9 +508,9 @@ describe Sprockets::Helpers do
         within_construct do |construct|
           assets_layout(construct)
           tags = context.javascript_tag('main.js', :expand => true)
-          expect(tags).to include('<script src="/assets/main.js?body=1"></script>')
-          expect(tags).to include('<script src="/assets/a.js?body=1"></script>')
-          expect(tags).to include('<script src="/assets/b.js?body=1"></script>')
+          expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
+          expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
+          expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
         end
       end
     end
@@ -536,9 +538,9 @@ describe Sprockets::Helpers do
         within_construct do |construct|
           assets_layout(construct)
           tags = context.stylesheet_tag('main.css', :expand => true)
-          expect(tags).to include('<link rel="stylesheet" href="/assets/main.css?body=1">')
-          expect(tags).to include('<link rel="stylesheet" href="/assets/a.css?body=1">')
-          expect(tags).to include('<link rel="stylesheet" href="/assets/b.css?body=1">')
+          expect(tags).to include('<link rel="stylesheet" href="/assets/main.self.css?body=1">')
+          expect(tags).to include('<link rel="stylesheet" href="/assets/a.self.css?body=1">')
+          expect(tags).to include('<link rel="stylesheet" href="/assets/b.self.css?body=1">')
         end
       end
     end

--- a/spec/sprockets-helpers_spec.rb
+++ b/spec/sprockets-helpers_spec.rb
@@ -444,16 +444,35 @@ describe Sprockets::Helpers do
         context.asset_tag('main.js', :expand => true) {}
       end
 
-      it 'generates tag for each asset' do
-        within_construct do |construct|
-          assets_layout(construct)
-          tags = context.asset_tag('main.js', :expand => true) do |path|
-            "<script src=\"#{path}\"></script>"
+      context "in Sprockets 2.x" do
+        next if Sprockets::Helpers.are_using_sprockets_3
+        it 'generates tag for each asset' do
+          within_construct do |construct|
+            assets_layout(construct)
+            tags = context.asset_tag('main.js', :expand => true) do |path|
+              "<script src=\"#{path}\"></script>"
+            end
+            expect(tags.split('</script>').size).to eq(3)
+            expect(tags).to include('<script src="/assets/main.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/a.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/b.js?body=1"></script>')
           end
-          expect(tags.split('</script>').size).to eq(3)
-          expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
-          expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
-          expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
+        end
+      end
+
+      context "in Sprockets 3.x" do
+        next unless Sprockets::Helpers.are_using_sprockets_3
+        it 'generates tag for each asset' do
+          within_construct do |construct|
+            assets_layout(construct)
+            tags = context.asset_tag('main.js', :expand => true) do |path|
+              "<script src=\"#{path}\"></script>"
+            end
+            expect(tags.split('</script>').size).to eq(3)
+            expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
+          end
         end
       end
     end
@@ -477,9 +496,16 @@ describe Sprockets::Helpers do
               "<script src=\"#{path}\"></script>"
             end
             expect(tags.split('</script>').size).to eq(3)
-            expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
-            expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
-            expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
+
+            if Sprockets::Helpers.are_using_sprockets_3
+              expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
+              expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
+              expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
+            else
+              expect(tags).to include('<script src="/assets/main.js?body=1"></script>')
+              expect(tags).to include('<script src="/assets/a.js?body=1"></script>')
+              expect(tags).to include('<script src="/assets/b.js?body=1"></script>')
+            end
 
             Sprockets::Helpers.debug = false
             Sprockets::Helpers.prefix = nil
@@ -504,13 +530,30 @@ describe Sprockets::Helpers do
     end
 
     describe 'when expanding' do
-      it 'generates script tag for each javascript asset' do
-        within_construct do |construct|
-          assets_layout(construct)
-          tags = context.javascript_tag('main.js', :expand => true)
-          expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
-          expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
-          expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
+      context 'in Sprockets 3.x' do
+        next unless Sprockets::Helpers.are_using_sprockets_3
+        it 'generates script tag for each javascript asset' do
+          within_construct do |construct|
+            assets_layout(construct)
+            tags = context.javascript_tag('main.js', :expand => true)
+            expect(tags).to include('<script src="/assets/main.self.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/a.self.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/b.self.js?body=1"></script>')
+          end
+        end
+      end
+
+      context 'in Sprockets 2.x' do
+        next if Sprockets::Helpers.are_using_sprockets_3
+        it 'generates script tag for each javascript asset' do
+          within_construct do |construct|
+            assets_layout(construct)
+            tags = context.javascript_tag('main.js', :expand => true)
+
+            expect(tags).to include('<script src="/assets/main.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/a.js?body=1"></script>')
+            expect(tags).to include('<script src="/assets/b.js?body=1"></script>')
+          end
         end
       end
     end
@@ -534,13 +577,29 @@ describe Sprockets::Helpers do
     end
 
     describe 'when expanding' do
-      it 'generates stylesheet tag for each stylesheet asset' do
-        within_construct do |construct|
-          assets_layout(construct)
-          tags = context.stylesheet_tag('main.css', :expand => true)
-          expect(tags).to include('<link rel="stylesheet" href="/assets/main.self.css?body=1">')
-          expect(tags).to include('<link rel="stylesheet" href="/assets/a.self.css?body=1">')
-          expect(tags).to include('<link rel="stylesheet" href="/assets/b.self.css?body=1">')
+      context 'in Sprockets 3.x' do
+        it 'generates stylesheet tag for each stylesheet asset' do
+          next unless Sprockets::Helpers.are_using_sprockets_3
+          within_construct do |construct|
+            assets_layout(construct)
+            tags = context.stylesheet_tag('main.css', :expand => true)
+            expect(tags).to include('<link rel="stylesheet" href="/assets/main.self.css?body=1">')
+            expect(tags).to include('<link rel="stylesheet" href="/assets/a.self.css?body=1">')
+            expect(tags).to include('<link rel="stylesheet" href="/assets/b.self.css?body=1">')
+          end
+        end
+      end
+
+      context "in Sprockets 2.x" do
+        next if Sprockets::Helpers.are_using_sprockets_3
+        it 'generates stylesheet tag for each stylesheet asset' do
+          within_construct do |construct|
+            assets_layout(construct)
+            tags = context.stylesheet_tag('main.css', :expand => true)
+            expect(tags).to include('<link rel="stylesheet" href="/assets/main.css?body=1">')
+            expect(tags).to include('<link rel="stylesheet" href="/assets/a.css?body=1">')
+            expect(tags).to include('<link rel="stylesheet" href="/assets/b.css?body=1">')
+          end
         end
       end
     end

--- a/sprockets-helpers.gemspec
+++ b/sprockets-helpers.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency             'sprockets',      '~> 2.0'
-  s.add_development_dependency 'appraisal',      '~> 0.5'
+  s.add_dependency             'sprockets',      '>= 2.0'
+  s.add_development_dependency 'appraisal',      '~> 2.0'
   s.add_development_dependency 'rspec',          '~> 2.13'
   s.add_development_dependency 'test_construct', '~> 2.0'
   s.add_development_dependency 'sinatra',        '~> 1.4'

--- a/sprockets-helpers.gemspec
+++ b/sprockets-helpers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split('\n').map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency             'sprockets',      '>= 2.0'
+  s.add_dependency             'sprockets',      '>= 2.2'
   s.add_development_dependency 'appraisal',      '~> 2.0'
   s.add_development_dependency 'rspec',          '~> 2.13'
   s.add_development_dependency 'test_construct', '~> 2.0'

--- a/sprockets-helpers.gemspec
+++ b/sprockets-helpers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency             'sprockets',      '~> 2.0'
   s.add_development_dependency 'appraisal',      '~> 0.5'
   s.add_development_dependency 'rspec',          '~> 2.13'
-  s.add_development_dependency 'test-construct', '~> 1.2'
+  s.add_development_dependency 'test_construct', '~> 2.0'
   s.add_development_dependency 'sinatra',        '~> 1.4'
   s.add_development_dependency 'rake'
 end

--- a/sprockets-helpers.gemspec
+++ b/sprockets-helpers.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |s|
   s.authors     = ['Pete Browne']
   s.email       = ['me@petebrowne.com']
   s.homepage    = 'https://github.com/petebrowne/sprockets-helpers'
-  s.summary     = 'Asset path helpers for Sprockets 2.x applications'
-  s.description = 'Asset path helpers for Sprockets 2.x applications'
+  s.summary     = 'Asset path helpers for Sprockets 2.x & 3.x applications'
+  s.description = 'Asset path helpers for Sprockets 2.x & 3.x applications'
 
   s.rubyforge_project = 'sprockets-helpers'
 


### PR DESCRIPTION
Hello :smile: 

I've started working on adopting Sprockets 3.x line and everything seems to be working as expected although I still want to make some tests.

Using both 2.x and 3.x requires version conditionals and I'm suggesting dropping 2.x support since there aren't any real disadvantages.

What do you think about that @petebrowne ?