### PR TITLE
Add mime type to javascript tags

### DIFF
--- a/lib/sprockets/helpers.rb
+++ b/lib/sprockets/helpers.rb
@@ -169,7 +169,7 @@ module Sprockets
     def javascript_tag(source, options = {})
       options = Helpers.default_path_options[:javascript_path].merge(options)
       asset_tag(source, options) do |path|
-        %Q(<script src="#{path}"></script>)
+        %Q(<script src="#{path}" type="text/javascript"></script>)
       end
     end
 


### PR DESCRIPTION
Javascript tags don't have their mime-types set with the `type` attribute. This causes serious errors when using https in some browsers. See https://github.com/gollum/gollum/issues/1496 for more info.

@petebrowne are you still accepting PRs for sprockets-helpers? Would be great if this fix could be released quickly! Many thanks for your work on the project over the years.